### PR TITLE
Add a trim option to remove memory address from the flamegraph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
+name = "futures"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+
+[[package]]
+name = "futures-task"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
+name = "futures-util"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +434,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,11 +516,12 @@ dependencies = [
 
 [[package]]
 name = "reap"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytesize",
  "inferno",
  "petgraph",
+ "rstest",
  "serde",
  "serde_json",
  "structopt",
@@ -436,6 +544,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 
 [[package]]
+name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "rustc_version",
+ "syn 1.0.105",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +589,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
@@ -476,6 +625,15 @@ dependencies = [
  "itoa 0.4.4",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reap"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["David Judd <david.a.judd@gmail.com>"]
 description = "A tool for parsing Ruby heap dumps"
 license = "Apache-2.0"
@@ -20,6 +20,9 @@ petgraph = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 timed_function = { version = "0.1", path = "timed_function" }
+
+[dev-dependencies]
+rstest = "0.16.0"
 
 [[bin]]
 name = "reap"

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -373,7 +373,7 @@ impl Analysis {
     // Produces valid input for inferno::flamegraph::from_lines
     //
     // The basic idea is that we treat every reachable byte as a sample.
-    pub fn flamegraph_lines(&self) -> Vec<String> {
+    pub fn flamegraph_lines(&self, trimmed:bool) -> Vec<String> {
         let mut lines = Vec::with_capacity(self.dominated_subgraph.node_count());
 
         // Re-usable buffer
@@ -389,12 +389,12 @@ impl Analysis {
 
             let mut line = String::new();
             for d in ancestors.iter().rev() {
-                write!(line, "{}", self.dominated_subgraph[*d]).unwrap();
+                write!(line, "{}", self.dominated_subgraph[*d].format(trimmed)).unwrap();
                 line.push_str(";");
             }
             ancestors.clear();
 
-            write!(line, "{}", node).unwrap();
+            write!(line, "{}", node.format(trimmed)).unwrap();
             line.push_str(" ");
             write!(line, "{}", node.bytes).unwrap();
 

--- a/src/object.rs
+++ b/src/object.rs
@@ -49,6 +49,19 @@ impl Object {
         ));
         clone
     }
+
+    pub fn format(&self, trimmed:bool) -> String {
+        if let Some(ref label) = self.label {
+           return format!("{}", label)
+        } else {
+            if trimmed {
+                self.kind.clone()
+            } else {
+                format!("{}[{:#x}]", self.kind, self.address)
+            }
+        }
+    }
+    
 }
 
 impl PartialEq for Object {

--- a/src/object.rs
+++ b/src/object.rs
@@ -50,11 +50,11 @@ impl Object {
         clone
     }
 
-    pub fn format(&self, trimmed:bool) -> String {
+    pub fn format(&self, class_name_only:bool) -> String {
         if let Some(ref label) = self.label {
            return format!("{}", label)
         } else {
-            if trimmed {
+            if class_name_only {
                 self.kind.clone()
             } else {
                 format!("{}[{:#x}]", self.kind, self.address)


### PR DESCRIPTION
We have a use-case to take the `flamegraph_lines` output and convert it to a `pprof`.  In order to do this for large heap dumps, we need to reduce the cardinality and have a condensed representation. To that end, I have added a `trim` option which changes the string representation of `Object` based on this flag.

As an example with `test/heap.json`:

![image](https://user-images.githubusercontent.com/4496584/217923147-20cbb96c-3312-4ce0-8a46-d5545f1d8e85.png)

Please let me know if there is a better/idiomatic Rust way of doing things here.

