### PR TITLE
Fix invalid utf-8 panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "reap"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytesize",
  "inferno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reap"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["David Judd <david.a.judd@gmail.com>"]
 description = "A tool for parsing Ruby heap dumps"
 license = "Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,4 +293,17 @@ mod test {
             assert_eq!(lines_with_memory_addresses, frame_lines.len());
         }
     }
+
+    #[rstest]
+    fn handles_invalid_utf8() {
+        let analysis = parse(Path::new("test/invalid-utf8.json"), None, false).unwrap();
+
+        let totals = analysis.dominated_totals();
+        assert_eq!(2, totals.count);
+        assert_eq!(40, totals.bytes);
+
+        let dom_graph = analysis.relevant_dominator_subgraph(0.005);
+        assert_eq!(2, dom_graph.node_count());
+        assert_eq!(1, dom_graph.edge_count());
+    }
 }

--- a/test/invalid-utf8.json
+++ b/test/invalid-utf8.json
@@ -1,0 +1,2 @@
+{"type":"ROOT", "root":"vm", "references":["0x7f83e10bbff0"]}
+{"address":"0x7f83e10bbff0", "type":"STRING", "class":"0x7f83df8cfc48", "embedded":true, "bytesize":3, "value":"ÿÿÿ", "memsize":40, "flags":{"wb_protected":true}}


### PR DESCRIPTION
This fixes a panic seen when non-utf8 data is in the heap. (ex: JPG is stored in a string value).