### PR TITLE
Fix a crash on certain ruby heaps that include non-utf-8 characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "reap"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bytesize",
  "inferno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reap"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["David Judd <david.a.judd@gmail.com>"]
 description = "A tool for parsing Ruby heap dumps"
 license = "Apache-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,9 +230,9 @@ mod test {
             .1;
 
         assert_eq!(9235, live_strs.count);
-        assert_eq!(1174, dead_strs.count);
+        assert_eq!(1175, dead_strs.count);
         assert_eq!(462583, live_strs.bytes);
-        assert_eq!(81799, dead_strs.bytes);
+        assert_eq!(81839, dead_strs.bytes);
         assert_eq!(9408, retained_strs.count);
         assert_eq!(486278, retained_strs.bytes);
 


### PR DESCRIPTION
Using `String::from_utf8_lossy` to fix crashes when the heap contains non-utf-8 data