### PR TITLE
Allow reap to be used as a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.3"
 authors = ["David Judd <david.a.judd@gmail.com>"]
 description = "A tool for parsing Ruby heap dumps"
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 homepage = "https://github.com/djudd/reap"
 repository = "https://github.com/djudd/reap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,9 @@ timed_function = { version = "0.1", path = "timed_function" }
 [dev-dependencies]
 rstest = "0.16.0"
 
+[features]
+timed = ["timed_function/timed"]
+default = ["timed"]
+
 [[bin]]
 name = "reap"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod analyze;
+pub mod object;
+pub mod parse;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 extern crate bytesize;
 extern crate inferno;
-#[macro_use]
-extern crate serde;
 extern crate petgraph;
 extern crate serde_json;
 extern crate structopt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use std::error;
 use std::fmt::Display;
 use std::fs::File;
 use std::io::prelude::*;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use structopt::StructOpt;
 
@@ -82,7 +83,9 @@ fn parse(
     rooted_at: Option<usize>,
     class_name_only: bool,
 ) -> std::io::Result<analyze::Analysis> {
-    let (root, graph) = parse::parse(file, class_name_only)?;
+    let file = File::open(file)?;
+    let mut reader = BufReader::new(file);
+    let (root, graph) = parse::parse(&mut reader, class_name_only)?;
 
     let subgraph_root = rooted_at
         .map(|address| {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -174,7 +174,7 @@ pub fn parse<R: BufRead>(
         }
     }
 
-    for mut obj in graph.node_weights_mut() {
+    for obj in graph.node_weights_mut() {
         if let Some(module) = instances.get(&obj.address) {
             if let Some(name) = names.get(module) {
                 obj.kind = name.to_owned();

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,6 +1,7 @@
 use crate::object::*;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::io::BufRead;
 use std::str;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -2,10 +2,7 @@ use crate::object::*;
 use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::prelude::*;
-use std::io::BufReader;
-use std::path::Path;
+use std::io::BufRead;
 use std::str;
 use timed_function::timed;
 
@@ -116,13 +113,10 @@ pub fn parse_address(addr: &str) -> Result<usize, std::num::ParseIntError> {
 }
 
 #[timed]
-pub fn parse(
-    file: &Path,
+pub fn parse<R: BufRead>(
+    reader: &mut R,
     class_name_only: bool,
 ) -> std::io::Result<(NodeIndex<usize>, ReferenceGraph)> {
-    let file = File::open(file)?;
-    let mut reader = BufReader::new(file);
-
     let mut graph: ReferenceGraph = Graph::default();
     let mut indices: HashMap<usize, NodeIndex<usize>> = HashMap::new();
     let mut references: HashMap<usize, Vec<usize>> = HashMap::new();
@@ -188,4 +182,63 @@ pub fn parse(
     }
 
     Ok((root_index, graph))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+    use std::fs::File;
+    use std::io::{BufReader, Cursor};
+    use std::path::Path;
+
+    #[derive(Default)]
+    struct TestInput {
+        input_file: String,
+        input_buffer: Cursor<Vec<u8>>,
+        class_name_only: bool,
+    }
+
+    #[rstest]
+    #[case::it_accepts_a_file_as_input(
+        TestInput {
+            input_file: "test/heap.json".to_string(),
+            ..Default::default()
+        },
+    )]
+    #[case::it_accepts_a_file_as_input_with_class_names_only(
+        TestInput {
+            input_file: "test/heap.json".to_string(),
+            class_name_only: true,
+            ..Default::default()
+        },
+    )]
+    fn test_parse_file(#[case] input: TestInput) {
+        let mut reader = {
+            let file = File::open(Path::new(input.input_file.as_str()));
+            assert!(file.is_ok());
+            BufReader::new(file.unwrap())
+        };
+        let res = parse(&mut reader, input.class_name_only);
+        assert!(res.is_ok());
+    }
+
+    #[rstest]
+    #[case::it_accepts_a_buffer_as_input(
+        TestInput {
+            input_buffer: Cursor::new(r#"{"type":"ROOT", "root":"vm", "references":[]}"#.to_string().into_bytes()),
+            ..Default::default()
+        },
+    )]
+    #[case::it_accepts_a_buffer_as_input_with_class_names_only(
+        TestInput {
+            input_buffer: Cursor::new(r#"{"type":"ROOT", "root":"vm", "references":[]}"#.to_string().into_bytes()),
+            class_name_only: true,
+            ..Default::default()
+        },
+    )]
+    fn test_parse_buffer(#[case] mut input: TestInput) {
+        let res = parse(&mut input.input_buffer, input.class_name_only);
+        assert!(res.is_ok());
+    }
 }

--- a/timed_function/Cargo.toml
+++ b/timed_function/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 [lib]
 proc-macro = true
 
+[features]
+timed = []
+
 [dependencies]
 syn = {version = "0.15.15", features = ["full"]}
 quote = "0.6.9"

--- a/timed_function/src/lib.rs
+++ b/timed_function/src/lib.rs
@@ -36,6 +36,7 @@ pub fn timed(_: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let funcname = &input.ident;
+    let generics = &input.decl.generics;
     let attributes = &input.attrs;
     let vis = &input.vis;
     let constness = &input.constness;
@@ -47,7 +48,7 @@ pub fn timed(_: TokenStream, item: TokenStream) -> TokenStream {
 
     quote!(
         #(#attributes),*
-        #vis #constness #unsafety #abi fn #funcname (#(#args),*) #output {
+        #vis #constness #unsafety #abi fn #funcname#generics (#(#args),*) #output {
             use std::time::{Duration, Instant};
 
             let start = Instant::now();

--- a/timed_function/src/lib.rs
+++ b/timed_function/src/lib.rs
@@ -5,18 +5,24 @@ extern crate quote;
 extern crate syn;
 
 use proc_macro::TokenStream;
-use quote::quote;
-use syn::{
-    parse_macro_input,
-    FnArg,
-    ItemFn,
-};
 
 #[proc_macro_attribute]
+#[cfg(not(feature = "timed"))]
+// no-op implementation of macro for when feature is disabled
+pub fn timed(_: TokenStream, item: TokenStream) -> TokenStream {
+    // Return the item as is when the feature is not enabled
+    item
+}
+
+#[proc_macro_attribute]
+#[cfg(feature = "timed")]
 /// Macro for wrapping functions with timing.
 ///
 /// ~Cargo-culted from https://github.com/Manishearth/rust-adorn/blob/master/src/lib.rs
 pub fn timed(_: TokenStream, item: TokenStream) -> TokenStream {
+    use quote::quote;
+    use syn::{parse_macro_input, FnArg, ItemFn};
+
     let input = parse_macro_input!(item as ItemFn);
 
     if input.decl.generics.where_clause.is_some() {
@@ -31,7 +37,7 @@ pub fn timed(_: TokenStream, item: TokenStream) -> TokenStream {
                 let pat = &cap.pat;
                 args.push(quote!(#pat: #ty));
             }
-             _ => panic!()
+            _ => panic!(),
         }
     }
 
@@ -58,6 +64,6 @@ pub fn timed(_: TokenStream, item: TokenStream) -> TokenStream {
 
             result
         }
-    ).into()
+    )
+    .into()
 }
-


### PR DESCRIPTION
I am working on a project that will process pub/sub messages for uploaded heap dumps, and convert them into SVGs.

I don't want to shell out to reap, I'd rather use it as a library for this use case.

I had to make a few changes to reap for this to work:

- Created lib.rs, and exposed the modules that reap's 'main.rs' uses as public modules
- Changed `parse::parse` signature to accept a generic that implements BufRead, so that I don't have to use a file on disk and can just pass it a buffer directly
- Updated the `timed` macro so that it plays nice with generics
- Put the `timed` macro behind a default on feature flag, so that the binary can still output function timing, but library uses don't have to have this printed to stdout

While I was in here, I bumped the rust edition and fixed a compiler warning that was coming up.

I added tests so that it should be clear that we can parse both from a file, and from an in-memory buffer.

The existing behaviour of the reap binary should be unchanged.

Since reap is not published to crates.io, I think it must be used as a git crate for now.