### PR TITLE
Increase error propagation of library functions

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -37,6 +37,8 @@ pub struct Analysis {
     class_name_only: bool,
 }
 
+type AnalysisResultType = (Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>);
+
 #[derive(Debug)]
 pub enum AnalysisError {
     NodeCountMismatch,
@@ -103,7 +105,7 @@ fn remove_unreachable(
     root: Index,
     graph: &ReferenceGraph,
     dominators: &HashMap<Index, Index>,
-) -> Result<(Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>), AnalysisError> {
+) -> Result<AnalysisResultType, AnalysisError> {
     // We take advantage of the fact that all reachable nodes have a dominator
     // to traverse the graph just once while both sorting reachable/unreachable
     // and translating domination edges into address terms
@@ -147,7 +149,7 @@ fn extract_dominated_subgraph(
     root: Index,
     graph: &ReferenceGraph,
     dominators: &HashMap<Index, Index>,
-) -> Result<(Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>), AnalysisError> {
+) -> Result<AnalysisResultType, AnalysisError> {
     let reachable = find_reachable_indices(root, graph);
     let dominator_addrs = find_addrs_of_filtered_edges(root, &reachable, dominators, graph);
 
@@ -319,7 +321,7 @@ fn largest_and_rest<'a, K, I: Iterator<Item = (&'a K, Stats)>>(
 ) -> (Vec<(&'a K, Stats)>, Stats) {
     let sorted = {
         let mut vec: Vec<(&'a K, Stats)> = iter.collect();
-        vec.sort_unstable_by_key(|(_, c)| usize::max_value() - c.bytes);
+        vec.sort_unstable_by_key(|(_, c)| usize::MAX - c.bytes);
         vec
     };
 

--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -4,6 +4,7 @@ use petgraph::graph::NodeIndex;
 use petgraph::visit::Dfs;
 use petgraph::Graph;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::fmt::Write;
 use std::iter::Iterator;
 use timed_function::timed;
@@ -36,31 +37,50 @@ pub struct Analysis {
     class_name_only: bool,
 }
 
+#[derive(Debug)]
+pub enum AnalysisError {
+    NodeCountMismatch,
+    DominatorAddrLengthExceeded,
+    // Other potential error types can be added here
+}
+
+impl fmt::Display for AnalysisError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            AnalysisError::NodeCountMismatch => write!(f, "Node count mismatch"),
+            AnalysisError::DominatorAddrLengthExceeded => {
+                write!(f, "Dominator addr length exceeded")
+            } // Add other variants as needed
+        }
+    }
+}
+impl std::error::Error for AnalysisError {}
+
 #[timed]
 pub fn analyze(
     orig_root: Index,
     subgraph_root: Index,
     graph: ReferenceGraph,
     class_name_only: bool,
-) -> Analysis {
+) -> Result<Analysis, AnalysisError> {
     let dominators = find_dominators(orig_root, &graph);
 
     let (root, dominated_subgraph, rest, dominators) = if subgraph_root == orig_root {
-        remove_unreachable(orig_root, &graph, &dominators)
+        remove_unreachable(orig_root, &graph, &dominators)?
     } else {
-        extract_dominated_subgraph(subgraph_root, &graph, &dominators)
+        extract_dominated_subgraph(subgraph_root, &graph, &dominators)?
     };
 
     let subtree_sizes = dominator_subtree_sizes(&dominated_subgraph, &dominators);
 
-    Analysis {
+    Ok(Analysis {
         root,
         dominated_subgraph,
         rest,
         dominators,
         subtree_sizes,
         class_name_only,
-    }
+    })
 }
 
 #[timed]
@@ -83,7 +103,7 @@ fn remove_unreachable(
     root: Index,
     graph: &ReferenceGraph,
     dominators: &HashMap<Index, Index>,
-) -> (Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>) {
+) -> Result<(Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>), AnalysisError> {
     // We take advantage of the fact that all reachable nodes have a dominator
     // to traverse the graph just once while both sorting reachable/unreachable
     // and translating domination edges into address terms
@@ -109,19 +129,17 @@ fn remove_unreachable(
         (reachable, unreachable, dominator_addrs)
     };
 
-    // Cheap sanity checks
-    assert_eq!(
-        reachable.node_count() + unreachable.len(),
-        graph.node_count()
-    );
-    assert!(dominator_addrs.len() <= reachable.node_count());
-
     // Prove that our optimization above does not change results vs checking reachability
     // separately
-    debug_assert!(reachable.node_count() == find_reachable_indices(root, graph).len());
+    if reachable.node_count() + unreachable.len() != graph.node_count() {
+        return Err(AnalysisError::NodeCountMismatch);
+    }
+    if dominator_addrs.len() > reachable.node_count() {
+        return Err(AnalysisError::DominatorAddrLengthExceeded);
+    }
 
     let (root, dominators) = map_indices(&reachable, &dominator_addrs, graph[root].address);
-    (root, reachable, unreachable, dominators)
+    Ok((root, reachable, unreachable, dominators))
 }
 
 #[timed]
@@ -129,7 +147,7 @@ fn extract_dominated_subgraph(
     root: Index,
     graph: &ReferenceGraph,
     dominators: &HashMap<Index, Index>,
-) -> (Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>) {
+) -> Result<(Index, ReferenceGraph, Vec<Object>, HashMap<Index, Index>), AnalysisError> {
     let reachable = find_reachable_indices(root, graph);
     let dominator_addrs = find_addrs_of_filtered_edges(root, &reachable, dominators, graph);
 
@@ -153,13 +171,15 @@ fn extract_dominated_subgraph(
         (dominated, not_dominated)
     };
 
-    // Cheap sanity checks
-    assert!(reachable.len() <= graph.node_count());
-    assert!(dominator_addrs.len() <= graph.node_count());
-    assert!(dominator_addrs.len() <= dominators.len());
-    assert!(dominator_addrs.len() <= reachable.len());
-    assert_eq!(dominated.node_count() + rest.len(), reachable.len());
-    assert!(dominated.node_count() <= dominator_addrs.len() + 1);
+    if reachable.len() > graph.node_count()
+        || dominator_addrs.len() > graph.node_count()
+        || dominator_addrs.len() > dominators.len()
+        || dominator_addrs.len() > reachable.len()
+        || dominated.node_count() + rest.len() != reachable.len()
+        || dominated.node_count() > dominator_addrs.len() + 1
+    {
+        return Err(AnalysisError::NodeCountMismatch);
+    }
 
     // Prove that the optimization of passing the reachable set to `find_addrs_of_filtered_edges`
     // does not change results
@@ -170,7 +190,7 @@ fn extract_dominated_subgraph(
     );
 
     let (root, dominators) = map_indices(&dominated, &dominator_addrs, graph[root].address);
-    (root, dominated, rest, dominators)
+    Ok((root, dominated, rest, dominators))
 }
 
 #[timed]
@@ -250,9 +270,9 @@ fn map_indices(
     let mapped_edges = {
         let mut mapped_edges: HashMap<Index, Index> = HashMap::new();
         for (a, d) in addr_edges {
-            let i = index_by_addr[a];
-            let j = index_by_addr[d];
-            mapped_edges.insert(i, j);
+            if let (Some(i), Some(j)) = (index_by_addr.get(a), index_by_addr.get(d)) {
+                mapped_edges.insert(*i, *j);
+            }
         }
         mapped_edges
     };
@@ -382,7 +402,7 @@ impl Analysis {
     // Produces valid input for inferno::flamegraph::from_lines
     //
     // The basic idea is that we treat every reachable byte as a sample.
-    pub fn flamegraph_lines(&self) -> Vec<String> {
+    pub fn flamegraph_lines(&self) -> Result<Vec<String>, std::fmt::Error> {
         let mut lines = Vec::with_capacity(self.dominated_subgraph.node_count());
 
         // Re-usable buffer
@@ -402,19 +422,18 @@ impl Analysis {
                     line,
                     "{}",
                     self.dominated_subgraph[*d].format(self.class_name_only)
-                )
-                .unwrap();
+                )?;
                 line.push(';');
             }
             ancestors.clear();
 
-            write!(line, "{}", node.format(self.class_name_only)).unwrap();
+            write!(line, "{}", node.format(self.class_name_only))?;
             line.push(' ');
-            write!(line, "{}", node.bytes).unwrap();
+            write!(line, "{}", node.bytes)?;
 
             lines.push(line);
         }
 
-        lines
+        Ok(lines)
     }
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -209,7 +209,7 @@ pub fn parse<R: BufRead>(
     for obj in graph.node_weights_mut() {
         if let Some(module) = instances.get(&obj.address) {
             if let Some(name) = names.get(module) {
-                obj.kind = name.to_owned();
+                name.clone_into(&mut obj.kind);
             }
         }
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -4,7 +4,7 @@ use petgraph::Graph;
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt;
-use std::io::{self, BufRead};
+use std::io::BufRead;
 use std::str;
 use timed_function::timed;
 
@@ -36,7 +36,6 @@ struct ParsedLine {
 
 #[derive(Debug)]
 pub enum ParseError {
-    IoError(io::Error),
     JsonError(serde_json::Error),
     InvalidLine(String),
 }
@@ -44,7 +43,6 @@ pub enum ParseError {
 impl fmt::Display for ParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParseError::IoError(err) => write!(f, "IO error: {}", err),
             ParseError::JsonError(err) => write!(f, "JSON error: {}", err),
             ParseError::InvalidLine(line) => write!(f, "Invalid line: {}", line),
         }
@@ -153,7 +151,7 @@ pub fn parse<R: BufRead>(
     let mut line_buffer = vec![];
 
     while let Ok(bytes_read) = reader.read_until(0x0A, &mut line_buffer) {
-        if bytes_read <= 0 {
+        if bytes_read == 0 {
             break;
         }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -3,7 +3,8 @@ use petgraph::graph::NodeIndex;
 use petgraph::Graph;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::io::BufRead;
+use std::fmt;
+use std::io::{self, BufRead};
 use std::str;
 use timed_function::timed;
 
@@ -32,6 +33,25 @@ struct ParsedLine {
     module: Option<usize>,
     name: Option<String>,
 }
+
+#[derive(Debug)]
+pub enum ParseError {
+    IoError(io::Error),
+    JsonError(serde_json::Error),
+    InvalidLine(String),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::IoError(err) => write!(f, "IO error: {}", err),
+            ParseError::JsonError(err) => write!(f, "JSON error: {}", err),
+            ParseError::InvalidLine(line) => write!(f, "Invalid line: {}", line),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
 
 impl Line {
     pub fn parse(self, class_name_only: bool) -> Option<ParsedLine> {
@@ -117,7 +137,7 @@ pub fn parse_address(addr: &str) -> Result<usize, std::num::ParseIntError> {
 pub fn parse<R: BufRead>(
     reader: &mut R,
     class_name_only: bool,
-) -> std::io::Result<(NodeIndex<usize>, ReferenceGraph)> {
+) -> Result<(NodeIndex<usize>, ReferenceGraph), ParseError> {
     let mut graph: ReferenceGraph = Graph::default();
     let mut indices: HashMap<usize, NodeIndex<usize>> = HashMap::new();
     let mut references: HashMap<usize, Vec<usize>> = HashMap::new();
@@ -137,28 +157,40 @@ pub fn parse<R: BufRead>(
             break;
         }
 
-        let line = String::from_utf8_lossy(&line_buffer);
+        let line = String::from_utf8_lossy(&line_buffer).to_string();
 
-        let parsed = serde_json::from_str::<Line>(&line)
-            .expect(&line)
+        let parsed: Result<ParsedLine, ParseError> = serde_json::from_str::<Line>(&line)
+            .map_err(ParseError::JsonError)?
             .parse(class_name_only)
-            .expect(&line);
+            .ok_or_else(|| ParseError::InvalidLine(line.clone()));
 
-        if parsed.object.is_root() {
-            let refs = references.get_mut(&root_address).unwrap();
-            refs.extend_from_slice(parsed.references.as_slice());
-        } else {
-            let address = parsed.object.address;
-            indices.insert(address, graph.add_node(parsed.object));
+        match parsed {
+            Ok(parsed) => {
+                if parsed.object.is_root() {
+                    let refs = references.get_mut(&root_address).ok_or_else(|| {
+                        ParseError::InvalidLine(format!(
+                            "Root address {} not found in references",
+                            root_address
+                        ))
+                    })?;
+                    refs.extend_from_slice(parsed.references.as_slice());
+                } else {
+                    let address = parsed.object.address;
+                    indices.insert(address, graph.add_node(parsed.object));
 
-            if !parsed.references.is_empty() {
-                references.insert(address, parsed.references);
+                    if !parsed.references.is_empty() {
+                        references.insert(address, parsed.references);
+                    }
+                    if let Some(module) = parsed.module {
+                        instances.insert(address, module);
+                    }
+                    if let Some(name) = parsed.name {
+                        names.insert(address, name);
+                    }
+                }
             }
-            if let Some(module) = parsed.module {
-                instances.insert(address, module);
-            }
-            if let Some(name) = parsed.name {
-                names.insert(address, name);
+            Err(e) => {
+                return Err(e);
             }
         }
 


### PR DESCRIPTION
# What

This adds error handling to src/analysis.rs and src/parse.rs, where it was otherwise lacking it. Afaict nothing to be done in src/object.rs. Note though that I **did not bother doing main.rs** as this is not called as a library. If called as a binary, it is fine to just explode and print the backtrace as we are doing now. Closes #11 

I have done away with all calls to:

- `unwrap`
- `expect`
- `assert!`

I also did a commit to address all `cargo clippy` warnings.

# Why

So that we should be able to safely call functions without worrying about them exploding and crashing the whole process if reap is used as a library if they encounter an error. Related to #10 

# How

Wherever possible, I've used `?` to propagate the error, otherwise errors are mapped to an error type where appropriate.

Function signatures that were missing a `Result` wrapper in the return type have had them added.

# Reviewers notes

The logic should be otherwise identical. Please verify that I didn't fudge this up!

**disclaimer** I had chat GPT do a lot of the heavy lifting here, please help me double-check the bot.

Please also verify I didn't miss any other cases where we should be propagating an error rather than panicking.
